### PR TITLE
Collapse php-tuf/phpcodesniffer-standard into project. (#266)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,8 @@
     "require-dev": {
         "phpunit/phpunit": "^8.5.8|^9",
         "symfony/phpunit-bridge": "^5",
-        "php-tuf/phpcodesniffer-standard": "dev-main"
+        "squizlabs/php_codesniffer": "^3.7",
+        "slevomat/coding-standard": "^8.2"
     },
     "license": "MIT",
     "minimum-stability": "dev",
@@ -32,15 +33,14 @@
             "Tuf\\Tests\\": "tests/"
         }
     },
-    "repositories": {
-        "php-tuf/phpcodesniffer-standard": {
-            "type": "git",
-            "url": "https://github.com/php-tuf/phpcodesniffer-standard"
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
         }
     },
     "scripts": {
-        "phpcs": "phpcs -s --standard=PhpTuf ./src ./tests",
-        "phpcbf": "phpcbf --standard=PhpTuf ./src ./tests",
+        "phpcs": "phpcs",
+        "phpcbf": "phpcbf",
         "test": "phpunit ./tests",
         "lint": "find src -name '*.php' -exec php -l {} \\;"
     }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-Ruleset -->
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         name="PhpTuf"
+         xsi:noNamespaceSchemaLocation="vendor/squizlabs/php_codesniffer/phpcs.xsd"
+>
+
+    <description>PHP TUF</description>
+
+    <arg name="colors"/>
+    <arg name="parallel" value="10"/>
+
+    <file>src</file>
+    <file>tests</file>
+
+    <!-- We basically follow PSR-2 -->
+    <rule ref="PSR2">
+        <exclude name="Generic.Files.LineLength.TooLong"/>
+    </rule>
+
+    <!-- Since PSR-2 / PSR-12 say nothing about variable lettercase, we choose a standard. -->
+    <rule ref="Squiz.NamingConventions.ValidVariableName.NotCamelCaps"/>
+    <rule ref="Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps"/>
+    <rule ref="Squiz.NamingConventions.ValidVariableName.StringNotCamelCaps"/>
+
+    <!-- PSR-2 doesn't enforce commenting standards.
+         https://github.com/squizlabs/PHP_CodeSniffer/issues/2314#issuecomment-448008052
+         https://www.php-fig.org/psr/psr-2/#7-conclusion
+         Add PEAR's rule to make sure comment indentation matches code.
+         @todo - breaks on switch statements.
+         @see https://github.com/php-tuf/php-tuf/issues/58
+    <rule ref="PEAR.WhiteSpace"/>
+    -->
+
+    <!-- Specify array formatting -->
+    <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
+    <rule ref="Generic.Arrays.ArrayIndent"/>
+    <rule ref="Squiz.Arrays.ArrayBracketSpacing"/>
+    <rule ref="Squiz.Arrays.ArrayDeclaration">
+        <!-- Disable some child rules that cause incorrect formatting. -->
+        <exclude name="Squiz.Arrays.ArrayDeclaration.CloseBraceNotAligned"/>
+        <exclude name="Squiz.Arrays.ArrayDeclaration.ValueNotAligned"/>
+        <exclude name="Squiz.Arrays.ArrayDeclaration.SingleLineNotAllowed"/>
+        <exclude name="Squiz.Arrays.ArrayDeclaration.KeyNotAligned"/>
+        <exclude name="Squiz.Arrays.ArrayDeclaration.DoubleArrowNotAligned"/>
+    </rule>
+
+    <!-- Find unused code -->
+    <rule ref="SlevomatCodingStandard.Namespaces.UnusedUses"/>
+
+</ruleset>


### PR DESCRIPTION
Aligning our joomla-tuf-combined branch with the main branch of php-tuf